### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.gitignore
+.git
+uptimerobot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.10-alpine as builder
+WORKDIR /go/src/github.com/bitfield/uptimerobot/
+ADD . .
+ENV CGO_ENABLED=0
+RUN apk --no-cache add git ca-certificates && \
+    go get -t . && \
+    go test && \
+    go build -o /uptimerobot
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /uptimerobot /uptimerobot
+ENTRYPOINT ["/uptimerobot"]


### PR DESCRIPTION
This PR adds a `Dockerfile` to build or use `uptimerobot` easily without a golang environment available.

It would be useful to publish an image on docker hub as well.