### PR TITLE
Fixes inconsistent API typing for sub_type

### DIFF
--- a/pkg/testdata/getMonitors.json
+++ b/pkg/testdata/getMonitors.json
@@ -3,7 +3,7 @@
     "pagination": {
         "offset": 0,
         "limit": 50,
-        "total": 2
+        "total": 3
     },
     "monitors": [
         {
@@ -73,6 +73,21 @@
                     "duration": 22
                 }
             ]
+        },
+        {
+            "id": 777559666,
+            "friendly_name": "My FTP Server",
+            "url": "ftp.mywebpage.com",
+            "type": 4,
+            "sub_type": 3,
+            "keyword_type": null,
+            "keyword_value": "",
+            "http_username": "",
+            "http_password": "",
+            "port": 21,
+            "interval": 60,
+            "status": 2,
+            "create_datetime": 0
         }
     ]
 }

--- a/pkg/uptimerobot.go
+++ b/pkg/uptimerobot.go
@@ -97,12 +97,12 @@ func (a AlertContact) String() string {
 
 // Monitor represents an UptimeRobot monitor.
 type Monitor struct {
-	ID           int64  `json:"id"`
-	FriendlyName string `json:"friendly_name"`
-	URL          string `json:"url"`
-	Type         int    `json:"type"`
-	SubType      string `json:"sub_type"`
-	// keyword_type is returned as either an integer or an empty string,
+	ID           int64       `json:"id"`
+	FriendlyName string      `json:"friendly_name"`
+	URL          string      `json:"url"`
+	Type         int         `json:"type"`
+	SubType      interface{} `json:"sub_type"`
+	// keyword_type and sub_type are returned as either an integer or an empty string,
 	// which Go doesn't allow: https://github.com/golang/go/issues/22182
 	KeywordType   interface{} `json:"keyword_type"`
 	KeywordValue  string      `json:"keyword_value"`

--- a/pkg/uptimerobot_test.go
+++ b/pkg/uptimerobot_test.go
@@ -132,7 +132,7 @@ func fakeGetMonitorsHandler(req *http.Request) (*http.Response, error) {
 }
 
 func TestGetMonitors(t *testing.T) {
-	want := []string{"Google", "My Web Page"}
+	want := []string{"Google", "My Web Page", "My FTP Server"}
 	c := New("dummy")
 	mockClient := MockHTTPClient{
 		DoFunc: fakeGetMonitorsHandler,


### PR DESCRIPTION
UptimeRobot API returns inconsistent types on `sub_type` (just like `keyword_type`).
This is addressed using `interface{}` instead of `int`

A test case has been added.

Should fix #5 